### PR TITLE
Sys - Package name change

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   path_provider: ^2.0.9
   filesystem_picker: ^2.0.0
   file_picker: ^4.5.1
-  flutter_quill:
+  visual_editor:
     path: ../
 
 dev_dependencies:


### PR DESCRIPTION
When building the example, i get this error:

> Error on line 1, column 7 of ..\pubspec.yaml: "name" field doesn't match expected name "flutter_quill".

This PR solves the problem.