### PR TITLE
Inputs - Remove late final from keyboardVisibilitySub

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -148,7 +148,7 @@ class VisualEditorState extends State<VisualEditor>
   final _editorKey = GlobalKey<State<VisualEditor>>();
   final _editorRendererKey = GlobalKey<State<VisualEditor>>();
   KeyboardVisibilityController? keyboardVisibilityCtrl;
-  late final StreamSubscription<bool>? keyboardVisibilitySub;
+  StreamSubscription<bool>? keyboardVisibilitySub;
   bool _didAutoFocus = false;
   DefaultStyles? styles;
   final ClipboardStatusNotifier clipboardStatus = ClipboardStatusNotifier();


### PR DESCRIPTION
This change was made in [dea76 commit](https://github.com/visual-space/visual-editor/commit/dea7644cf9f17b5cdd80e272d48ae1343ec18a09#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L159). 
This commit reverts this change because of the following problem.

It causes the problem:
```
══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
The following LateError was thrown while finalizing the widget tree:
LateInitializationError: Field 'keyboardVisibilitySub' has not been initialized.
When the exception was thrown, this was the stack:
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 266:49  throw_
packages/visual_editor/main.dart 152:40                                       get keyboardVisibilitySub
packages/visual_editor/editor/services/editor.service.dart 47:11              disposeEditor
packages/visual_editor/main.dart 233:20                                       dispose
packages/flutter/src/widgets/framework.dart 5088:11                           unmount
packages/flutter/src/widgets/framework.dart 1917:12                           [_unmount]
packages/flutter/src/widgets/framework.dart 1915:7                            <fn>
packages/flutter/src/widgets/framework.dart 6381:16                           visitChildren
...
```
Similar problem discussed on SO:
https://stackoverflow.com/questions/69309379/lateinitializationerror-field-has-not-been-initialized-in-flutter