### PR TITLE
Blocks - Rendering/layout related events

### DIFF
--- a/lib/blocks/widgets/editable-text-line-renderer.dart
+++ b/lib/blocks/widgets/editable-text-line-renderer.dart
@@ -451,6 +451,12 @@ class EditableTextLineRenderer extends EditableBoxRenderer {
   }
 
   @override
+  void layout(Constraints constraints, {bool parentUsesSize = false}) {
+    _state.refs.editorController.onLayoutParagraph?.call(this, container);
+    super.layout(constraints, parentUsesSize: parentUsesSize);
+  }
+
+  @override
   void performLayout() {
     final constraints = this.constraints;
     _selectedRects = null;

--- a/lib/controller/controllers/editor-controller.dart
+++ b/lib/controller/controllers/editor-controller.dart
@@ -1,5 +1,6 @@
 import 'dart:math' as math;
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 
 import '../../documents/models/attribute.model.dart';
@@ -9,6 +10,7 @@ import '../../documents/models/delta/delta.model.dart';
 import '../../documents/models/document.model.dart';
 import '../../documents/models/nodes/embeddable.model.dart';
 import '../../documents/models/nodes/leaf.model.dart';
+import '../../documents/models/nodes/node.model.dart';
 import '../../documents/models/style.model.dart';
 import '../../documents/services/delta.utils.dart';
 import '../../embeds/models/image.model.dart';
@@ -73,6 +75,8 @@ class EditorController {
   DeleteCallback? onDelete;
   void Function()? onSelectionCompleted;
   void Function(TextSelection textSelection)? onSelectionChanged;
+  void Function()? onPreLayout;
+  void Function(RenderBox renderer, NodeM block)? onLayoutParagraph;
   bool ignoreFocusOnTextChange = false;
 
   // Store any styles attribute that got toggled by the tap of a button and that has not been applied yet.
@@ -113,6 +117,8 @@ class EditorController {
     this.onDelete,
     this.onSelectionCompleted,
     this.onSelectionChanged,
+    this.onPreLayout,
+    this.onLayoutParagraph,
   }) {
     _state.document.setDocument(document);
   }

--- a/lib/editor/widgets/editor-renderer-inner.dart
+++ b/lib/editor/widgets/editor-renderer-inner.dart
@@ -143,6 +143,8 @@ class EditorRendererInner extends MultilineTextAreaRenderer
       );
     }());
 
+    _state.refs.editorController.onPreLayout?.call();
+
     resolvePadding();
     assert(resolvedPadding != null);
 


### PR DESCRIPTION
This adds two callbacks, one that is called whenever a line/paragraph is rendered and the other that is called before the editor is redrawn. These two callbacks can be used in combination to do stuff like adding custom highlighting.

Example Usecase (based on all-styles.page.dart):
```dart
  Future<void> _loadDocument() async {
    final result = await rootBundle.loadString('assets/docs/all-styles.json');
    final document = DocumentM.fromJson(jsonDecode(result));

    setState(() {
      _controller = EditorController(
        onPreLayout: onPreLayout,
        onLayoutParagraph: onRenderParagraphCallback,
        document: document,
        highlights: SAMPLE_HIGHLIGHTS,
      );
    });
  }

  void onPreLayout() {
    //remove all the old highlights
    SAMPLE_HIGHLIGHTS
        .clear(); //yes, I was too lazy to create my own List<HighlightM>.
    print("");
    print("----------------CLEAN---------------");
    print("");
  }

  void onRenderParagraphCallback(RenderBox renderer, NodeM m) {
    return;
    final rawText = m.toPlainText();

    final searchtext = "ipsum";
    searchtext.allMatches(rawText).forEach((match) {
      var globalStart = match.start + m.documentOffset;
      int globalEnd = match.end + m.documentOffset;

      SAMPLE_HIGHLIGHTS.add(
        HighlightM(
            textSelection: TextSelection(
              baseOffset: globalStart,
              extentOffset: globalEnd,
            ),
            onEnter: (_) {
              // print('Entering highlight 1');
            },
            onLeave: (_) {
              // print('Leaving highlight 1');
            },
            onSingleTapUp: (_) {
              // print('Tapped highlight 1');
            }),
      );
    });
  }
```