### PR TITLE
[PR] Fixing `Null` errors on app startup and selecting text 

### DIFF
--- a/lib/document/controllers/document.controller.dart
+++ b/lib/document/controllers/document.controller.dart
@@ -412,6 +412,11 @@ class DocumentController {
   NodePositionM queryChild(int offset) {
     // TODO: prevent user from moving caret after last line-break.
     final nodePos = _contUtils.queryChild(rootNode, offset, true);
+    
+    // If the node is null, we return the rootNode's `NodeM`.
+    if (nodePos.node == null) {
+      return NodePositionM(rootNode.defaultChild, 0);
+    }
 
     if (nodePos.node is LineM) {
       return nodePos;

--- a/lib/selection/services/selection-handles.service.dart
+++ b/lib/selection/services/selection-handles.service.dart
@@ -136,7 +136,7 @@ class SelectionHandlesService {
 
     final controller = state.refs.widget.selectionHandlesController;
     final hasSelection = controller == null;
-    final hasToolbarAlready = controller!.toolbar != null;
+    final hasToolbarAlready = hasSelection ? true : controller!.toolbar != null;
 
     if (hasSelection || hasToolbarAlready) {
       return false;


### PR DESCRIPTION
Hopefully closes #239 

I'm not entirely sure if the change I've made in `queryChild` is correct, which is why I want to advise discretion before merging this. 

I'm getting the error when the app starts and I tap on the editor to start typing. Because `nodePos.node` is null, it errors out. I could ignore this error but it makes it impossible to unit/integration test the app :\

Thanks!