### PR TITLE
Feature: Add checkBoxReadOnly property which can override readOnly for checkbox

### DIFF
--- a/lib/doc-tree/services/doc-tree.service.dart
+++ b/lib/doc-tree/services/doc-tree.service.dart
@@ -302,7 +302,7 @@ class DocTreeService {
 
   // Updates the checkbox positioned at [offset] in document by changing its attribute according to [value].
   void _handleCheckboxTap(int offset, bool value) {
-    if (!state.config.readOnly) {
+    if (!(state.config.checkBoxReadOnly ?? state.config.readOnly)) {
       state.scrollAnimation.disabled = true;
       final attribute = value ? AttributesAliasesM.checked : AttributesAliasesM.unchecked;
 

--- a/lib/doc-tree/widgets/editable-text-block.dart
+++ b/lib/doc-tree/widgets/editable-text-block.dart
@@ -217,7 +217,7 @@ class EditableTextBlock extends StatelessWidget {
       return CheckboxPoint(
         size: 14,
         value: true,
-        enabled: !_state.config.readOnly,
+        enabled: !(_state.config.checkBoxReadOnly ?? _state.config.readOnly),
         onChanged: (checked) => onCheckboxTap(lineOffset, checked),
         uiBuilder: styles.lists?.checkboxUIBuilder,
       );
@@ -228,7 +228,7 @@ class EditableTextBlock extends StatelessWidget {
       return CheckboxPoint(
         size: 14,
         value: false,
-        enabled: !_state.config.readOnly,
+        enabled: !(_state.config.checkBoxReadOnly ?? _state.config.readOnly),
         onChanged: (checked) => onCheckboxTap(lineOffset, checked),
         uiBuilder: styles.lists?.checkboxUIBuilder,
       );

--- a/lib/editor/models/editor-cfg.model.dart
+++ b/lib/editor/models/editor-cfg.model.dart
@@ -43,6 +43,12 @@ class EditorConfigM {
   // The text remains selectable.
   final bool readOnly;
 
+  // Override [readOnly] for checkbox.
+  // When this is set to `false`, the checkbox can be checked or unchecked while [readOnly] is set to `true`.
+  // When this is set to `true`, the checkbox cannot be checked or unchecked while [readOnly] is set to `false`.
+  // When this is set to `null`, the [readOnly] value is used.
+  final bool? checkBoxReadOnly;
+
   // Content to be displayed when there is no content in the Delta document
   final String? placeholder;
 
@@ -198,6 +204,7 @@ class EditorConfigM {
     this.padding = EdgeInsets.zero,
     this.autoFocus = false,
     this.readOnly = false,
+    this.checkBoxReadOnly,
     this.expands = false,
     this.paintCursorAboveText,
     this.placeholder,
@@ -254,6 +261,7 @@ class EditorConfigM {
     bool? autoFocus,
     bool? paintCursorAboveText,
     bool? readOnly,
+    bool? checkBoxReadOnly,
     String? placeholder,
     bool? enableInteractiveSelection,
     double? minHeight,
@@ -299,6 +307,7 @@ class EditorConfigM {
       autoFocus: autoFocus ?? this.autoFocus,
       paintCursorAboveText: paintCursorAboveText ?? this.paintCursorAboveText,
       readOnly: readOnly ?? this.readOnly,
+      checkBoxReadOnly: checkBoxReadOnly ?? this.checkBoxReadOnly,
       placeholder: placeholder ?? this.placeholder,
       enableInteractiveSelection: enableInteractiveSelection ?? this.enableInteractiveSelection,
       minHeight: minHeight ?? this.minHeight,


### PR DESCRIPTION
This PR add `checkBoxReadOnly` property, which can override `readOnly` for checkbox. This allow checkbox to be checked or unchecked while `readOnly` is set to `true`.